### PR TITLE
[watchdog] Fix watchdog test_arm_disarm_states condition and a proper message description

### DIFF
--- a/tests/platform_tests/api/test_watchdog.py
+++ b/tests/platform_tests/api/test_watchdog.py
@@ -75,7 +75,7 @@ class TestWatchdogApi(PlatformApiTestBase):
         if self.expect(actual_timeout is not None, "Watchdog.arm is not supported"):
             if self.expect(isinstance(actual_timeout, int), "actual_timeout appears incorrect"):
                 if self.expect(actual_timeout != -1, "Failed to arm the watchdog"):
-                    self.expect(actual_timeout >= watchdog_timeout, "Actual watchdog timeout {} seconds appears wrong, should be less than {} seconds".format(actual_timeout, watchdog_timeout))
+                    self.expect(actual_timeout >= watchdog_timeout, "Actual watchdog timeout {} seconds appears wrong, should be equal or greater than {} seconds".format(actual_timeout, watchdog_timeout))
 
         watchdog_status = watchdog.is_armed(platform_api_conn)
         if self.expect(watchdog_status is not None, "Failed to retrieve watchdog status"):
@@ -85,7 +85,7 @@ class TestWatchdogApi(PlatformApiTestBase):
 
         if self.expect(remaining_time is not None, "Failed to get the remaining time of watchdog"):
             if self.expect(isinstance(remaining_time, int), "remaining_time appears incorrect"):
-                self.expect(remaining_time <= watchdog_timeout, "Watchdog remaining_time {} seconds appears wrong compared to watchdog timeout {} seocnds".format(remaining_time))
+                self.expect(remaining_time <= actual_timeout, "Watchdog remaining_time {} seconds appears wrong compared to watchdog timeout {} seocnds".format(remaining_time))
 
         watchdog_status = watchdog.disarm(platform_api_conn)
         if self.expect(watchdog_status is not None, "Watchdog.disarm is not supported"):


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Change test_arm_disarm_states condition watchdog_timeout -> actual_timeout like it should be.
Fix msg description.

#### How did you do it?

#### How did you verify/test it?
Run test_watchdog.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
