### PR TITLE
Fix test_psu on API tests

### DIFF
--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -37,6 +37,7 @@ STATUS_LED_COLOR_OFF = "off"
 def gather_facts(request, duthost):
     # Get platform facts from platform.json file
     request.cls.chassis_facts = duthost.facts.get("chassis")
+    request.cls.asic_type = duthost.facts.get("asic_type")
 
 
 @pytest.mark.usefixtures("gather_facts")
@@ -196,28 +197,32 @@ class TestPsuApi(PlatformApiTestBase):
 
     def test_led(self, duthost, localhost, platform_api_conn):
         ''' PSU status led test '''
-
         FAULT_LED_COLOR_LIST = [
             STATUS_LED_COLOR_AMBER,
             STATUS_LED_COLOR_ORANGE,
             STATUS_LED_COLOR_RED
         ]
-        OFF_LED_COLOR_LIST = [
-            STATUS_LED_COLOR_OFF
-        ]
+
         NORMAL_LED_COLOR_LIST = [
             STATUS_LED_COLOR_GREEN
         ]
 
+        OFF_LED_COLOR_LIST = [
+            STATUS_LED_COLOR_OFF
+        ]
+
         LED_COLOR_TYPES = []
         LED_COLOR_TYPES.append(FAULT_LED_COLOR_LIST)
-        LED_COLOR_TYPES.append(OFF_LED_COLOR_LIST)
         LED_COLOR_TYPES.append(NORMAL_LED_COLOR_LIST)
+
+        # Mellanox is not supporting set leds to 'off'
+        if self.asic_type != "mellanox":
+            LED_COLOR_TYPES.append(OFF_LED_COLOR_LIST)
 
         LED_COLOR_TYPES_DICT = {
             0: "fault",
-            1: "off",
-            2: "normal"
+            1: "normal",
+            2: "off"
         }   
 
         for psu_id in range(self.num_psus):


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Each platform support different LED colors, but the functionality is the same.
This fix group LED colors into groups of same logical meaning and test accordingly, with no need to define vendor and platform specific LED colors.

#### How did you do it?
Group same logical LED colors into different Led "types".

#### How did you verify/test it?
Run the test on any platform.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
