### PR TITLE
Fix test_fan_drawer_fans on API tests

### DIFF
--- a/tests/platform_tests/api/test_fan_drawer_fans.py
+++ b/tests/platform_tests/api/test_fan_drawer_fans.py
@@ -34,6 +34,7 @@ FAN_DIRECTION_NOT_APPLICABLE = "N/A"
 
 STATUS_LED_COLOR_GREEN = "green"
 STATUS_LED_COLOR_AMBER = "amber"
+STATUS_LED_COLOR_ORANGE = "orange"
 STATUS_LED_COLOR_RED = "red"
 STATUS_LED_COLOR_OFF = "off"
 
@@ -41,6 +42,7 @@ STATUS_LED_COLOR_OFF = "off"
 def gather_facts(request, duthost):
     # Get platform facts from platform.json file
     request.cls.chassis_facts = duthost.facts.get("chassis")
+    request.cls.asic_type = duthost.facts.get("asic_type")
 
 
 @pytest.mark.usefixtures("gather_facts")
@@ -260,30 +262,52 @@ class TestFanDrawerFans(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_set_fans_led(self, duthost, localhost, platform_api_conn):
-        LED_COLOR_LIST = [
-            "off",
-            "red",
-            "amber",
-            "green",
+
+        FAULT_LED_COLOR_LIST = [
+            STATUS_LED_COLOR_AMBER,
+            STATUS_LED_COLOR_ORANGE,
+            STATUS_LED_COLOR_RED
         ]
 
+        NORMAL_LED_COLOR_LIST = [
+            STATUS_LED_COLOR_GREEN
+        ]
+
+        OFF_LED_COLOR_LIST = [
+            STATUS_LED_COLOR_OFF
+        ]
+
+        LED_COLOR_TYPES = []
+        LED_COLOR_TYPES.append(FAULT_LED_COLOR_LIST)
+        LED_COLOR_TYPES.append(NORMAL_LED_COLOR_LIST)
+
+        # Mellanox is not supporting set leds to 'off'
+        if self.asic_type != "mellanox":
+            LED_COLOR_TYPES.append(OFF_LED_COLOR_LIST)
+
+        LED_COLOR_TYPES_DICT = {
+            0: "fault",
+            1: "normal",
+            2: "off"
+        }
 
         for j in range(self.num_fan_drawers):
             num_fans = fan_drawer.get_num_fans(platform_api_conn, j)
 
             for i in range(num_fans):
-
-                for color in LED_COLOR_LIST:
-
-                    result = fan_drawer_fan.set_status_led(platform_api_conn, j, i, color)
-                    if self.expect(result is not None, "Failed to perform set_status_led"):
-                        self.expect(result is True, "Failed to set status_led for fan drawer {} fan {} to {}".format(j , i, color))
-
-                    color_actual = fan_drawer_fan.get_status_led(platform_api_conn, j, i)
-
-                    if self.expect(color_actual is not None, "Failed to retrieve status_led"):
-                        if self.expect(isinstance(color_actual, STRING_TYPE), "Status LED color appears incorrect"):
-                            self.expect(color == color_actual, "Status LED color incorrect (expected: {}, actual: {} for fan {})".format(
-                                color, color_actual, i))
+                for index, led_type in enumerate(LED_COLOR_TYPES):
+                    led_type_result = False
+                    for color in led_type:
+                        result = fan_drawer_fan.set_status_led(platform_api_conn, j, i, color)
+                        if self.expect(result is not None, "Failed to perform set_status_led"):
+                            led_type_result = result or led_type_result
+                        if ((result is None) or (not result)):
+                            continue
+                        color_actual = fan_drawer_fan.get_status_led(platform_api_conn, j, i)
+                        if self.expect(color_actual is not None, "Failed to retrieve status_led"):
+                            if self.expect(isinstance(color_actual, STRING_TYPE), "Status LED color appears incorrect"):
+                                self.expect(color == color_actual, "Status LED color incorrect (expected: {}, actual: {} for fan {})".format(
+                                    color, color_actual, i))
+                    self.expect(result is True, "Failed to set status_led for fan drawer {} fan {} to {}".format(j , i, LED_COLOR_TYPES_DICT[index]))
 
         self.assert_expectations()


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Each platform support different LED colors, but the functionality is the same.
This fix group LED colors into groups of same logical meaning and test accordingly, with no need to define vendor and platform specific LED colors.

#### How did you do it?
Group same logical LED colors into different Led "types".

#### How did you verify/test it?
Run the test on any platform.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
