### PR TITLE
[sensors] Adapt Mellanox platforms parameters to run sensors test on all branches.

### DIFF
--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -1150,7 +1150,7 @@ sensors_checks:
       - dps460-i2c-4-59/PSU-2 12V Rail (out)/in3_max_alarm
       - dps460-i2c-4-59/PSU-2 12V Rail (out)/in3_min_alarm
       temp:
-      - coretemp-isa-0000/Physical id 0/temp1_crit_alarm
+      - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_crit_alarm
       - coretemp-isa-0000/Core 0/temp2_crit_alarm
       - coretemp-isa-0000/Core 1/temp3_crit_alarm
       - coretemp-isa-0000/Core 2/temp4_crit_alarm
@@ -1237,8 +1237,8 @@ sensors_checks:
     compares:
       power: []
       temp:
-      - - coretemp-isa-0000/Physical id 0/temp1_input
-        - coretemp-isa-0000/Physical id 0/temp1_max
+      - - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_input
+        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_max
       - - coretemp-isa-0000/Core 0/temp2_input
         - coretemp-isa-0000/Core 0/temp2_max
       - - coretemp-isa-0000/Core 1/temp3_input
@@ -1356,7 +1356,7 @@ sensors_checks:
       - dps460-i2c-4-59/PSU-2 12V Rail (out)/in3_max_alarm
       - dps460-i2c-4-59/PSU-2 12V Rail (out)/in3_min_alarm
       temp:
-      - coretemp-isa-0000/Physical id 0/temp1_crit_alarm
+      - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_crit_alarm
       - coretemp-isa-0000/Core 0/temp2_crit_alarm
       - coretemp-isa-0000/Core 1/temp3_crit_alarm
 
@@ -1441,8 +1441,8 @@ sensors_checks:
     compares:
       power: []
       temp:
-      - - coretemp-isa-0000/Physical id 0/temp1_input
-        - coretemp-isa-0000/Physical id 0/temp1_max
+      - - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_input
+        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_max
       - - coretemp-isa-0000/Core 0/temp2_input
         - coretemp-isa-0000/Core 0/temp2_max
       - - coretemp-isa-0000/Core 1/temp3_input
@@ -1569,7 +1569,7 @@ sensors_checks:
       - dps460-i2c-4-59/PSU-2 12V Rail (out)/in3_max_alarm
       - dps460-i2c-4-59/PSU-2 12V Rail (out)/in3_min_alarm
       temp:
-      - coretemp-isa-0000/Physical id 0/temp1_crit_alarm
+      - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_crit_alarm
       - coretemp-isa-0000/Core 0/temp2_crit_alarm
       - coretemp-isa-0000/Core 1/temp3_crit_alarm
       - coretemp-isa-0000/Core 2/temp4_crit_alarm
@@ -1698,8 +1698,8 @@ sensors_checks:
     compares:
       power: []
       temp:
-      - - coretemp-isa-0000/Physical id 0/temp1_input
-        - coretemp-isa-0000/Physical id 0/temp1_max
+      - - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_input
+        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_max
       - - coretemp-isa-0000/Core 0/temp2_input
         - coretemp-isa-0000/Core 0/temp2_max
       - - coretemp-isa-0000/Core 1/temp3_input
@@ -1906,7 +1906,7 @@ sensors_checks:
       - dps460-i2c-4-59/PSU-2(R) 12V Rail (out)/in3_max_alarm
       - dps460-i2c-4-59/PSU-2(R) 12V Rail (out)/in3_min_alarm
       temp:
-      - coretemp-isa-0000/Physical id 0/temp1_crit_alarm
+      - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_crit_alarm
       - coretemp-isa-0000/Core 0/temp2_crit_alarm
       - coretemp-isa-0000/Core 1/temp3_crit_alarm
       - coretemp-isa-0000/Core 2/temp4_crit_alarm
@@ -2006,8 +2006,8 @@ sensors_checks:
     compares:
       power: []
       temp:
-      - - coretemp-isa-0000/Physical id 0/temp1_input
-        - coretemp-isa-0000/Physical id 0/temp1_max
+      - - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_input
+        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_max
       - - coretemp-isa-0000/Core 0/temp2_input
         - coretemp-isa-0000/Core 0/temp2_max
       - - coretemp-isa-0000/Core 1/temp3_input
@@ -3245,7 +3245,7 @@ sensors_checks:
       - dps460-i2c-4-59/PSU-2 220V Rail Curr (in)/curr1_max_alarm
       - dps460-i2c-4-59/PSU-2 12V Rail Curr (out)/curr2_max_alarm
       temp:
-      - coretemp-isa-0000/Physical id 0/temp1_crit_alarm
+      - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_crit_alarm
       - coretemp-isa-0000/Core 0/temp2_crit_alarm
       - coretemp-isa-0000/Core 1/temp3_crit_alarm
       - mlxsw-i2c-2-48/front panel 001/temp2_fault
@@ -3337,8 +3337,8 @@ sensors_checks:
     compares:
       power: []
       temp:
-      - - coretemp-isa-0000/Physical id 0/temp1_input
-        - coretemp-isa-0000/Physical id 0/temp1_max
+      - - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_input
+        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_max
       - - coretemp-isa-0000/Core 0/temp2_input
         - coretemp-isa-0000/Core 0/temp2_max
       - - coretemp-isa-0000/Core 1/temp3_input
@@ -3358,7 +3358,7 @@ sensors_checks:
       temp: []
     psu_skips: {}
 
-x86_64-mlnx_msn4410-r0:
+  x86_64-mlnx_msn4410-r0:
     alarms:
       fan:
       - dps460-i2c-4-58/PSU-1(L) Fan 1/fan1_alarm
@@ -3535,7 +3535,7 @@ x86_64-mlnx_msn4410-r0:
       - dps460-i2c-4-59/PSU-2(R) 12V Rail (out)/in3_max_alarm
       - dps460-i2c-4-59/PSU-2(R) 12V Rail (out)/in3_min_alarm
       temp:
-      - coretemp-isa-0000/Physical id 0/temp1_crit_alarm
+      - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_crit_alarm
       - coretemp-isa-0000/Core 0/temp2_crit_alarm
       - coretemp-isa-0000/Core 1/temp3_crit_alarm
       - coretemp-isa-0000/Core 2/temp4_crit_alarm
@@ -3627,14 +3627,15 @@ x86_64-mlnx_msn4410-r0:
       - dps460-i2c-4-59/PSU-2(R) Temp 1/temp1_crit_alarm
       - dps460-i2c-4-59/PSU-2(R) Temp 1/temp1_max_alarm
       - dps460-i2c-4-59/PSU-2(R) Temp 2/temp2_crit_alarm
-      - dps460-i2c-4-59/PSU-2(R) Temp 2/temp2_max_alarm
+      # Temporary commented the line beyond in order to test_sensors.py passing for SN4410 (Redmine bug - 2327108)
+      #- dps460-i2c-4-59/PSU-2(R) Temp 2/temp2_max_alarm
       - dps460-i2c-4-59/PSU-2(R) Temp 3/temp3_crit_alarm
       - dps460-i2c-4-59/PSU-2(R) Temp 3/temp3_max_alarm
     compares:
       power: []
       temp:
-      - - coretemp-isa-0000/Physical id 0/temp1_input
-        - coretemp-isa-0000/Physical id 0/temp1_max
+      - - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_input
+        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_max
       - - coretemp-isa-0000/Core 0/temp2_input
         - coretemp-isa-0000/Core 0/temp2_max
       - - coretemp-isa-0000/Core 1/temp3_input
@@ -3656,14 +3657,293 @@ x86_64-mlnx_msn4410-r0:
       fan: []
       power: []
       temp: []
-    psu_skips:
-      dps460-i2c-4-58:
-        number: 2
-        side: right
-        skip_list:
-        - dps460-i2c-4-58
-      dps460-i2c-4-59:
-        number: 1
-        side: left
-        skip_list:
-        - dps460-i2c-4-59
+    psu_skips: {}
+
+  x86_64-mlnx_msn4600c-r0:
+    alarms:
+      fan:
+      - dps460-i2c-4-58/PSU-1(L) Fan 1/fan1_alarm
+      - dps460-i2c-4-58/PSU-1(L) Fan 1/fan1_fault
+
+      - dps460-i2c-4-59/PSU-2(R) Fan 1/fan1_alarm
+      - dps460-i2c-4-59/PSU-2(R) Fan 1/fan1_fault
+
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-1/fan1_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-2/fan2_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-3/fan3_fault
+
+      power:
+      - xdpe12284-i2c-5-62/PMIC-1 ASIC 12V VCORE_MAIN Rail Curr (in)/curr1_max_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 ASIC 0.8V VCORE_MAIN Rail Curr (out)/curr3_max_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 ASIC 0.8V VCORE_MAIN Rail Curr (out)/curr3_crit_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 PSU 12V Rail (in)/in1_lcrit_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 PSU 12V Rail (in)/in1_crit_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 ASIC 0.8V VCORE_MAIN Rail (out)/in3_crit_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 ASIC 0.8V VCORE_MAIN Rail (out)/in3_lcrit_alarm
+
+      - xdpe12284-i2c-5-64/PMIC-2 ASIC 12V Rail_1 Curr (in)/curr1_max_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 ASIC 12V Rail_2 Curr (in)/curr2_max_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.8V Rail_1 Curr (out)/curr3_max_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.8V Rail_1 Curr (out)/curr3_crit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.2V Rail_2 Curr (out)/curr4_max_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.2V Rail_2 Curr (out)/curr4_crit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 PSU 12V Rail_1 (in)/in1_lcrit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 PSU 12V Rail_1 (in)/in1_crit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 PSU 12V Rail_2 (in)/in2_lcrit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 PSU 12V Rail_2 (in)/in2_crit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.8V Rail_1 (out)/in3_crit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.8V Rail_1 (out)/in3_lcrit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.2V Rail_2 (out)/in4_crit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.2V Rail_2 (out)/in4_lcrit_alarm
+
+      - xdpe12284-i2c-5-66/PMIC-3 ASIC 12V Rail_1 Curr (in)/curr1_max_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 ASIC 12V Rail_2 Curr (in)/curr2_max_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 ASIC 0.85V Rail_1 T0_1 Curr (out)/curr3_max_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 ASIC 0.85V Rail_1 T0_1 Curr (out)/curr3_crit_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 ASIC 1.8V Rail_2 T0_1 Curr (out)/curr4_max_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 ASIC 1.8V Rail_2 T0_1 Curr (out)/curr4_crit_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 PSU 12V Rail_1 (in)/in1_lcrit_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 PSU 12V Rail_1 (in)/in1_crit_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 PSU 12V Rail_2 (in)/in2_lcrit_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 PSU 12V Rail_2 (in)/in2_crit_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 ASIC 0.85V Rail_1 T0_1 (out)/in3_crit_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 ASIC 0.85V Rail_1 T0_1 (out)/in3_lcrit_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 ASIC 1.8V Rail_2 T0_1 (out)/in4_crit_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 ASIC 1.8V Rail_2 T0_1 (out)/in4_lcrit_alarm
+
+      - xdpe12284-i2c-5-68/PMIC-4 ASIC 12V Rail_1 Curr (in)/curr1_max_alarm
+      - xdpe12284-i2c-5-68/PMIC-4 ASIC 12V Rail_2 Curr (in)/curr2_max_alarm
+      - xdpe12284-i2c-5-68/PMIC-4 ASIC 0.85V Rail_1 T2_3 Curr (out)/curr3_max_alarm
+      - xdpe12284-i2c-5-68/PMIC-4 ASIC 0.85V Rail_1 T2_3 Curr (out)/curr3_crit_alarm
+      - xdpe12284-i2c-5-68/PMIC-4 ASIC 1.8V Rail_2 T2_3 Curr (out)/curr4_max_alarm
+      - xdpe12284-i2c-5-68/PMIC-4 ASIC 1.8V Rail_2 T2_3 Curr (out)/curr4_crit_alarm
+      - xdpe12284-i2c-5-68/PMIC-4 PSU 12V Rail_1 (in)/in1_lcrit_alarm
+      - xdpe12284-i2c-5-68/PMIC-4 PSU 12V Rail_1 (in)/in1_crit_alarm
+      - xdpe12284-i2c-5-68/PMIC-4 PSU 12V Rail_2 (in)/in2_lcrit_alarm
+      - xdpe12284-i2c-5-68/PMIC-4 PSU 12V Rail_2 (in)/in2_crit_alarm
+      - xdpe12284-i2c-5-68/PMIC-4 ASIC 0.85V Rail_1 T2_3 (out)/in3_crit_alarm
+      - xdpe12284-i2c-5-68/PMIC-4 ASIC 0.85V Rail_1 T2_3 (out)/in3_lcrit_alarm
+      - xdpe12284-i2c-5-68/PMIC-4 ASIC 1.8V Rail_2 T2_3 (out)/in4_crit_alarm
+      - xdpe12284-i2c-5-68/PMIC-4 ASIC 1.8V Rail_2 T2_3 (out)/in4_lcrit_alarm
+
+      - xdpe12284-i2c-5-6a/PMIC-5 ASIC 12V Rail_1 Curr (in)/curr1_max_alarm
+      - xdpe12284-i2c-5-6a/PMIC-5 ASIC 12V Rail_2 Curr (in)/curr2_max_alarm
+      - xdpe12284-i2c-5-6a/PMIC-5 ASIC 0.85V Rail_1 T4_5 Curr (out)/curr3_max_alarm
+      - xdpe12284-i2c-5-6a/PMIC-5 ASIC 0.85V Rail_1 T4_5 Curr (out)/curr3_crit_alarm
+      - xdpe12284-i2c-5-6a/PMIC-5 ASIC 1.8V Rail_2 T4_5 Curr (out)/curr4_max_alarm
+      - xdpe12284-i2c-5-6a/PMIC-5 ASIC 1.8V Rail_2 T4_5 Curr (out)/curr4_crit_alarm
+      - xdpe12284-i2c-5-6a/PMIC-5 PSU 12V Rail_1 (in)/in1_lcrit_alarm
+      - xdpe12284-i2c-5-6a/PMIC-5 PSU 12V Rail_1 (in)/in1_crit_alarm
+      - xdpe12284-i2c-5-6a/PMIC-5 PSU 12V Rail_2 (in)/in2_lcrit_alarm
+      - xdpe12284-i2c-5-6a/PMIC-5 PSU 12V Rail_2 (in)/in2_crit_alarm
+      - xdpe12284-i2c-5-6a/PMIC-5 ASIC 0.85V Rail_1 T4_5 (out)/in3_crit_alarm
+      - xdpe12284-i2c-5-6a/PMIC-5 ASIC 0.85V Rail_1 T4_5 (out)/in3_lcrit_alarm
+      - xdpe12284-i2c-5-6a/PMIC-5 ASIC 1.8V Rail_2 T4_5 (out)/in4_crit_alarm
+      - xdpe12284-i2c-5-6a/PMIC-5 ASIC 1.8V Rail_2 T4_5 (out)/in4_lcrit_alarm
+
+      - xdpe12284-i2c-5-6c/PMIC-6 ASIC 12V Rail_1 Curr (in)/curr1_max_alarm
+      - xdpe12284-i2c-5-6c/PMIC-6 ASIC 12V Rail_2 Curr (in)/curr2_max_alarm
+      - xdpe12284-i2c-5-6c/PMIC-6 ASIC 0.85V Rail_1 T6_7 Curr (out)/curr3_max_alarm
+      - xdpe12284-i2c-5-6c/PMIC-6 ASIC 0.85V Rail_1 T6_7 Curr (out)/curr3_crit_alarm
+      - xdpe12284-i2c-5-6c/PMIC-6 ASIC 1.8V Rail_2 T6_7 Curr (out)/curr4_max_alarm
+      - xdpe12284-i2c-5-6c/PMIC-6 ASIC 1.8V Rail_2 T6_7 Curr (out)/curr4_crit_alarm
+      - xdpe12284-i2c-5-6c/PMIC-6 PSU 12V Rail_1 (in)/in1_lcrit_alarm
+      - xdpe12284-i2c-5-6c/PMIC-6 PSU 12V Rail_1 (in)/in1_crit_alarm
+      - xdpe12284-i2c-5-6c/PMIC-6 PSU 12V Rail_2 (in)/in2_lcrit_alarm
+      - xdpe12284-i2c-5-6c/PMIC-6 PSU 12V Rail_2 (in)/in2_crit_alarm
+      - xdpe12284-i2c-5-6c/PMIC-6 ASIC 0.85V Rail_1 T6_7 (out)/in3_crit_alarm
+      - xdpe12284-i2c-5-6c/PMIC-6 ASIC 0.85V Rail_1 T6_7 (out)/in3_lcrit_alarm
+      - xdpe12284-i2c-5-6c/PMIC-6 ASIC 1.8V Rail_2 T6_7 (out)/in4_crit_alarm
+      - xdpe12284-i2c-5-6c/PMIC-6 ASIC 1.8V Rail_2 T6_7 (out)/in4_lcrit_alarm
+
+      - xdpe12284-i2c-5-6e/PMIC-7 ASIC 12V Rail_1 Curr (in)/curr1_max_alarm
+      - xdpe12284-i2c-5-6e/PMIC-7 ASIC 12V Rail_2 Curr (in)/curr2_max_alarm
+      - xdpe12284-i2c-5-6e/PMIC-7 ASIC 1.2V Rail_1 T0_3 Curr (out)/curr3_max_alarm
+      - xdpe12284-i2c-5-6e/PMIC-7 ASIC 1.2V Rail_1 T0_3 Curr (out)/curr3_crit_alarm
+      - xdpe12284-i2c-5-6e/PMIC-7 ASIC 1.2V Rail_2 T4_7 Curr (out)/curr4_max_alarm
+      - xdpe12284-i2c-5-6e/PMIC-7 ASIC 1.2V Rail_2 T4_7 Curr (out)/curr4_crit_alarm
+      - xdpe12284-i2c-5-6e/PMIC-7 PSU 12V Rail_1 (in)/in1_lcrit_alarm
+      - xdpe12284-i2c-5-6e/PMIC-7 PSU 12V Rail_1 (in)/in1_crit_alarm
+      - xdpe12284-i2c-5-6e/PMIC-7 PSU 12V Rail_2 (in)/in2_lcrit_alarm
+      - xdpe12284-i2c-5-6e/PMIC-7 PSU 12V Rail_2 (in)/in2_crit_alarm
+      - xdpe12284-i2c-5-6e/PMIC-7 ASIC 1.2V Rail_1 T0_3 (out)/in3_crit_alarm
+      - xdpe12284-i2c-5-6e/PMIC-7 ASIC 1.2V Rail_1 T0_3 (out)/in3_lcrit_alarm
+      - xdpe12284-i2c-5-6e/PMIC-7 ASIC 1.2V Rail_2 T4_7 (out)/in4_crit_alarm
+      - xdpe12284-i2c-5-6e/PMIC-7 ASIC 1.2V Rail_2 T4_7 (out)/in4_lcrit_alarm
+
+      - tps53679-i2c-15-58/PMIC-8 COMEX 1.8V Rail Curr (out)/curr1_crit_alarm
+      - tps53679-i2c-15-58/PMIC-8 COMEX 1.8V Rail Curr (out)/curr1_max_alarm
+      - tps53679-i2c-15-58/PMIC-8 COMEX 1.05V Rail Curr (out)/curr2_crit_alarm
+      - tps53679-i2c-15-58/PMIC-8 COMEX 1.05V Rail Curr (out)/curr2_max_alarm
+      - tps53679-i2c-15-58/PMIC-8 PSU 12V Rail (in1)/in1_alarm
+      - tps53679-i2c-15-58/PMIC-8 PSU 12V Rail (in2)/in2_alarm
+      - tps53679-i2c-15-58/PMIC-8 COMEX 1.8V Rail (out)/in3_crit_alarm
+      - tps53679-i2c-15-58/PMIC-8 COMEX 1.8V Rail (out)/in3_lcrit_alarm
+      - tps53679-i2c-15-58/PMIC-8 COMEX 1.05V Rail (out)/in4_crit_alarm
+      - tps53679-i2c-15-58/PMIC-8 COMEX 1.05V Rail (out)/in4_lcrit_alarm
+
+      - tps53679-i2c-15-61/PMIC-9 COMEX 1.2V Rail Curr (out)/curr1_crit_alarm
+      - tps53679-i2c-15-61/PMIC-9 COMEX 1.2V Rail Curr (out)/curr1_max_alarm
+      - tps53679-i2c-15-61/PMIC-9 PSU 12V Rail (in1)/in1_alarm
+      - tps53679-i2c-15-61/PMIC-9 PSU 12V Rail (in2)/in2_alarm
+      - tps53679-i2c-15-61/PMIC-9 COMEX 1.2V Rail (out)/in3_crit_alarm
+      - tps53679-i2c-15-61/PMIC-9 COMEX 1.2V Rail (out)/in3_lcrit_alarm
+
+      - dps460-i2c-4-58/PSU-1(L) 220V Rail Curr (in)/curr1_crit_alarm
+      - dps460-i2c-4-58/PSU-1(L) 220V Rail Curr (in)/curr1_max_alarm
+      - dps460-i2c-4-58/PSU-1(L) 12V Rail Curr (out)/curr2_crit_alarm
+      - dps460-i2c-4-58/PSU-1(L) 12V Rail Curr (out)/curr2_max_alarm
+      - dps460-i2c-4-58/PSU-1(L) 220V Rail Pwr (in)/power1_alarm
+      - dps460-i2c-4-58/PSU-1(L) 12V Rail Pwr (out)/power2_crit_alarm
+      - dps460-i2c-4-58/PSU-1(L) 12V Rail Pwr (out)/power2_max_alarm
+      - dps460-i2c-4-58/PSU-1(L) 220V Rail (in)/in1_crit_alarm
+      - dps460-i2c-4-58/PSU-1(L) 220V Rail (in)/in1_lcrit_alarm
+      - dps460-i2c-4-58/PSU-1(L) 220V Rail (in)/in1_max_alarm
+      - dps460-i2c-4-58/PSU-1(L) 220V Rail (in)/in1_min_alarm
+      - dps460-i2c-4-58/PSU-1(L) 12V Rail (out)/in3_crit_alarm
+      - dps460-i2c-4-58/PSU-1(L) 12V Rail (out)/in3_lcrit_alarm
+      - dps460-i2c-4-58/PSU-1(L) 12V Rail (out)/in3_max_alarm
+      - dps460-i2c-4-58/PSU-1(L) 12V Rail (out)/in3_min_alarm
+
+      - dps460-i2c-4-59/PSU-2(R) 220V Rail Curr (in)/curr1_crit_alarm
+      - dps460-i2c-4-59/PSU-2(R) 220V Rail Curr (in)/curr1_max_alarm
+      - dps460-i2c-4-59/PSU-2(R) 12V Rail Curr (out)/curr2_crit_alarm
+      - dps460-i2c-4-59/PSU-2(R) 12V Rail Curr (out)/curr2_max_alarm
+      - dps460-i2c-4-59/PSU-2(R) 220V Rail Pwr (in)/power1_alarm
+      - dps460-i2c-4-59/PSU-2(R) 12V Rail Pwr (out)/power2_crit_alarm
+      - dps460-i2c-4-59/PSU-2(R) 12V Rail Pwr (out)/power2_max_alarm
+      - dps460-i2c-4-59/PSU-2(R) 220V Rail (in)/in1_crit_alarm
+      - dps460-i2c-4-59/PSU-2(R) 220V Rail (in)/in1_lcrit_alarm
+      - dps460-i2c-4-59/PSU-2(R) 220V Rail (in)/in1_max_alarm
+      - dps460-i2c-4-59/PSU-2(R) 220V Rail (in)/in1_min_alarm
+      - dps460-i2c-4-59/PSU-2(R) 12V Rail (out)/in3_crit_alarm
+      - dps460-i2c-4-59/PSU-2(R) 12V Rail (out)/in3_lcrit_alarm
+      - dps460-i2c-4-59/PSU-2(R) 12V Rail (out)/in3_max_alarm
+      - dps460-i2c-4-59/PSU-2(R) 12V Rail (out)/in3_min_alarm
+
+      temp:
+      - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_crit_alarm
+      - coretemp-isa-0000/Core 0/temp2_crit_alarm
+      - coretemp-isa-0000/Core 1/temp3_crit_alarm
+      - coretemp-isa-0000/Core 2/temp4_crit_alarm
+      - coretemp-isa-0000/Core 3/temp5_crit_alarm
+
+      - mlxsw-i2c-2-48/front panel 001/temp2_fault
+      - mlxsw-i2c-2-48/front panel 002/temp3_fault
+      - mlxsw-i2c-2-48/front panel 003/temp4_fault
+      - mlxsw-i2c-2-48/front panel 004/temp5_fault
+      - mlxsw-i2c-2-48/front panel 005/temp6_fault
+      - mlxsw-i2c-2-48/front panel 006/temp7_fault
+      - mlxsw-i2c-2-48/front panel 007/temp8_fault
+      - mlxsw-i2c-2-48/front panel 008/temp9_fault
+      - mlxsw-i2c-2-48/front panel 009/temp10_fault
+      - mlxsw-i2c-2-48/front panel 010/temp11_fault
+      - mlxsw-i2c-2-48/front panel 011/temp12_fault
+      - mlxsw-i2c-2-48/front panel 012/temp13_fault
+      - mlxsw-i2c-2-48/front panel 013/temp14_fault
+      - mlxsw-i2c-2-48/front panel 014/temp15_fault
+      - mlxsw-i2c-2-48/front panel 015/temp16_fault
+      - mlxsw-i2c-2-48/front panel 016/temp17_fault
+      - mlxsw-i2c-2-48/front panel 017/temp18_fault
+      - mlxsw-i2c-2-48/front panel 018/temp19_fault
+      - mlxsw-i2c-2-48/front panel 019/temp20_fault
+      - mlxsw-i2c-2-48/front panel 020/temp21_fault
+      - mlxsw-i2c-2-48/front panel 021/temp22_fault
+      - mlxsw-i2c-2-48/front panel 022/temp23_fault
+      - mlxsw-i2c-2-48/front panel 023/temp24_fault
+      - mlxsw-i2c-2-48/front panel 024/temp25_fault
+      - mlxsw-i2c-2-48/front panel 025/temp26_fault
+      - mlxsw-i2c-2-48/front panel 026/temp27_fault
+      - mlxsw-i2c-2-48/front panel 027/temp28_fault
+      - mlxsw-i2c-2-48/front panel 028/temp29_fault
+      - mlxsw-i2c-2-48/front panel 029/temp30_fault
+      - mlxsw-i2c-2-48/front panel 030/temp31_fault
+      - mlxsw-i2c-2-48/front panel 031/temp32_fault
+      - mlxsw-i2c-2-48/front panel 032/temp33_fault
+
+      - xdpe12284-i2c-5-62/PMIC-1 Temp 1/temp1_crit_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 Temp 1/temp1_max_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 Temp 2/temp2_crit_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 Temp 2/temp2_max_alarm
+
+      - xdpe12284-i2c-5-64/PMIC-2 Temp 1/temp1_crit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 Temp 1/temp1_max_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 Temp 2/temp2_crit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 Temp 2/temp2_max_alarm
+
+      - xdpe12284-i2c-5-66/PMIC-3 Temp 1/temp1_crit_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 Temp 1/temp1_max_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 Temp 2/temp2_crit_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 Temp 2/temp2_max_alarm
+
+      - xdpe12284-i2c-5-68/PMIC-4 Temp 1/temp1_crit_alarm
+      - xdpe12284-i2c-5-68/PMIC-4 Temp 1/temp1_max_alarm
+      - xdpe12284-i2c-5-68/PMIC-4 Temp 2/temp2_crit_alarm
+      - xdpe12284-i2c-5-68/PMIC-4 Temp 2/temp2_max_alarm
+
+      - xdpe12284-i2c-5-6a/PMIC-5 Temp 1/temp1_crit_alarm
+      - xdpe12284-i2c-5-6a/PMIC-5 Temp 1/temp1_max_alarm
+      - xdpe12284-i2c-5-6a/PMIC-5 Temp 2/temp2_crit_alarm
+      - xdpe12284-i2c-5-6a/PMIC-5 Temp 2/temp2_max_alarm
+
+      - xdpe12284-i2c-5-6c/PMIC-6 Temp 1/temp1_crit_alarm
+      - xdpe12284-i2c-5-6c/PMIC-6 Temp 1/temp1_max_alarm
+      - xdpe12284-i2c-5-6c/PMIC-6 Temp 2/temp2_crit_alarm
+      - xdpe12284-i2c-5-6c/PMIC-6 Temp 2/temp2_max_alarm
+
+      - xdpe12284-i2c-5-6e/PMIC-7 Temp 1/temp1_crit_alarm
+      - xdpe12284-i2c-5-6e/PMIC-7 Temp 1/temp1_max_alarm
+      - xdpe12284-i2c-5-6e/PMIC-7 Temp 2/temp2_crit_alarm
+      - xdpe12284-i2c-5-6e/PMIC-7 Temp 2/temp2_max_alarm
+
+      - tps53679-i2c-15-58/PMIC-8 Temp 1/temp1_crit_alarm
+      - tps53679-i2c-15-58/PMIC-8 Temp 1/temp1_max_alarm
+      - tps53679-i2c-15-58/PMIC-8 Temp 2/temp2_crit_alarm
+      - tps53679-i2c-15-58/PMIC-8 Temp 2/temp2_max_alarm
+
+      - tps53679-i2c-15-61/PMIC-9 Temp 1/temp1_crit_alarm
+      - tps53679-i2c-15-61/PMIC-9 Temp 1/temp1_max_alarm
+      - tps53679-i2c-15-61/PMIC-9 Temp 2/temp2_crit_alarm
+      - tps53679-i2c-15-61/PMIC-9 Temp 2/temp2_max_alarm
+
+      - dps460-i2c-4-58/PSU-1(L) Temp 1/temp1_crit_alarm
+      - dps460-i2c-4-58/PSU-1(L) Temp 1/temp1_max_alarm
+      - dps460-i2c-4-58/PSU-1(L) Temp 2/temp2_crit_alarm
+      - dps460-i2c-4-58/PSU-1(L) Temp 2/temp2_max_alarm
+      - dps460-i2c-4-58/PSU-1(L) Temp 3/temp3_crit_alarm
+      - dps460-i2c-4-58/PSU-1(L) Temp 3/temp3_max_alarm
+
+      - dps460-i2c-4-59/PSU-2(R) Temp 1/temp1_crit_alarm
+      - dps460-i2c-4-59/PSU-2(R) Temp 1/temp1_max_alarm
+      - dps460-i2c-4-59/PSU-2(R) Temp 2/temp2_crit_alarm
+      - dps460-i2c-4-59/PSU-2(R) Temp 2/temp2_max_alarm
+      - dps460-i2c-4-59/PSU-2(R) Temp 3/temp3_crit_alarm
+      - dps460-i2c-4-59/PSU-2(R) Temp 3/temp3_max_alarm
+
+    compares:
+      power: []
+      temp:
+      - - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_input
+        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_max
+      - - coretemp-isa-0000/Core 0/temp2_input
+        - coretemp-isa-0000/Core 0/temp2_max
+      - - coretemp-isa-0000/Core 1/temp3_input
+        - coretemp-isa-0000/Core 1/temp3_max
+      - - coretemp-isa-0000/Core 2/temp4_input
+        - coretemp-isa-0000/Core 2/temp4_max
+      - - coretemp-isa-0000/Core 3/temp5_input
+        - coretemp-isa-0000/Core 3/temp5_max
+
+      - - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_input
+        - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_max
+
+      - - tmp102-i2c-7-4a/Ambient Port Side Temp (air exhaust)/temp1_input
+        - tmp102-i2c-7-4a/Ambient Port Side Temp (air exhaust)/temp1_max
+
+      - - tmp102-i2c-15-49/Ambient COMEX Temp/temp1_input
+        - tmp102-i2c-15-49/Ambient COMEX Temp/temp1_max
+    non_zero:
+      fan: []
+      power: []
+      temp: []
+    psu_skips: {}


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
CPU parameters varies between the branches - Package / Physical representation for the CPU.
This fix will allow using a regex expression to be suitable for both terms.
Add MSN4600C platform parameters.

#### How did you do it?
Use a regex expression instead of a fix "Package" or "Physical" term.
Add MSN4600C platform parameters.

#### How did you verify/test it?
Run the test using images based on all branches.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
